### PR TITLE
Update dependencies

### DIFF
--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -60,7 +60,7 @@ function run() {
 
 function printUsage() {
   console.log([
-    'Usage: react-web <command>',
+    'Usage: react-native-winjs <command>',
     '',
     'Commands:'
   ].concat(Object.keys(documentedCommands).map(function(name) {
@@ -75,7 +75,7 @@ function printInitWarning() {
   return Promise.resolve().then(function() {
     console.log([
       'Looks like React Web project already exists in the current',
-      'folder. Run this command from a different folder or remove node_modules/react-web'
+      'folder. Run this command from a different folder or remove node_modules/react-native-winjs'
     ].join('\n'));
     process.exit(1);
   });

--- a/local-cli/generator-web/index.js
+++ b/local-cli/generator-web/index.js
@@ -31,7 +31,7 @@ function installDev(projectDir, verbose) {
     } else {
       console.log(chalk.white.bold('To run your app on browser:'));
       console.log(chalk.white('   cd ' + projectDir));
-      console.log(chalk.white('   react-web start'));
+      console.log(chalk.white('   react-native-winjs start'));
     }
   });
 }

--- a/local-cli/generator-web/templates/webpack.config.js
+++ b/local-cli/generator-web/templates/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
       'react-native': 'react-native-winjs',
       'ReactNativeART': 'react-art',
     },
-    extensions: ['', '.js', '.jsx'],
+    extensions: ['', '.js', '.jsx', '.ios.js', '.jpg', '.png', '.css', '.md'],
   },
   entry: isProd? [
     config.paths.index

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react": "3.13.1",
     "file-loader": "0.8.4",
     "haste-resolver-webpack-plugin": "0.1.3",
-    "jest-cli": "0.4.5",
+    "jest-cli": "0.8.2",
     "json-loader": "0.5.2",
     "react-hot-loader": "1.2.7",
     "url-loader": "0.5.6",
@@ -40,16 +40,16 @@
     "webpack-merge": "0.1.1"
   },
   "peerDependencies": {
-    "react": "~0.14.0",
-    "react-dom": "~0.14.0"
+    "react": "~0.14.7",
+    "react-dom": "~0.14.7"
   },
   "dependencies": {
-    "babel-core": "5.8.19",
+    "babel-core": "6.4.5",
     "chalk": "1.1.1",
     "core-js": "1.2.3",
     "domkit": "0.0.1",
     "easyfile": "0.1.0",
-    "fbjs": "0.2.1",
+    "fbjs": "^0.6.0",
     "graceful-fs": "4.1.2",
     "history": "1.12.6",
     "immutable": "3.7.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ var mergeCommon = merge.bind(null, {
       'react-native': 'ReactNativeWinJS',
       'ReactART': 'react-art'
     },
-    extensions: ['', '.js', '.jsx', '.md', '.css', '.png', '.jpg'],
+    extensions: ['', '.js', '.jsx', '.ios.js', '.md', '.css', '.png', '.jpg'],
   },
   module: {
     loaders: [{


### PR DESCRIPTION
This fixes should allow webpack to select automatically `componentName.ios.js` as a primary component and ignore `componentName.android.js`. Also, it contains some package updates and renames `react-web` to `react-native-winjs` in CLI messages so it won't confuse users.
